### PR TITLE
Fix for gulp-stylus

### DIFF
--- a/lib/font-face.styl
+++ b/lib/font-face.styl
@@ -5,10 +5,7 @@ font-face(family, font=family, path='fonts')
   @font-face
     font-family family
     src url(file(font, 'eot', path))
-    src url(file(font, 'eot?#iefix', path)) format("embedded-opentype"),
-      url(file(font, 'woff', path)) format("woff"),
-      url(file(font, 'ttf', path)) format("truetype"),
-      url(file(font, 'svg#' + family, path)) format("svg")
+    src url(file(font, 'eot?#iefix', path)) format("embedded-opentype"), url(file(font, 'woff', path)) format("woff"), url(file(font, 'ttf', path)) format("truetype"), url(file(font, 'svg#' + family, path)) format("svg")
     font-weight normal
     font-style normal
 
@@ -18,8 +15,6 @@ font-face-inline(family, font=family, path='fonts')
     src url(file(font, 'eot?', path)) format("embedded-opentype")
   @font-face
     font-family family
-    src data-url(file(font, 'woff', path)) format("woff"),
-      data-url(file(font, 'ttf', path)) format("truetype"),
-      url(file(font, 'svg#' + family, path)) format("svg")
+    src data-url(file(font, 'woff', path)) format("woff"), data-url(file(font, 'ttf', path)) format("truetype"), url(file(font, 'svg#' + family, path)) format("svg")
     font-weight normal
     font-style normal


### PR DESCRIPTION
The line breaks caused the compile to fail when using with gulp-stylus
