### PR TITLE
[WIP]: Add CDN path option to font-face-inline.

### DIFF
--- a/lib/font-face.styl
+++ b/lib/font-face.styl
@@ -12,14 +12,14 @@ font-face(family, font=family, path='fonts', weight='normal', style='normal')
     font-weight weight
     font-style style
 
-font-face-inline(family, font=family, path='fonts', weight=400, style='normal')
+font-face-inline(family, font=family, path='fonts', weight=400, style='normal', cdnPath=path)
   @font-face
     font-family family
-    src url(file(font, 'eot?', path)) format("embedded-opentype")
+    src url(file(font, 'eot?', cdnPath)) format("embedded-opentype")
   @font-face
     font-family family
     src data-url(file(font, 'woff', path)) format("woff"),
       data-url(file(font, 'ttf', path)) format("truetype"),
-      url(file(font, 'svg#' + family, path)) format("svg")
+      url(file(font, 'svg#' + family, cdnPath)) format("svg")
     font-weight weight
     font-style style


### PR DESCRIPTION
`path` option for `font-face-inline` must be relative path from the stylus file.
When I want to use CDN for font and style the path that cause problem.

Add  `cdnPath` to set custom url path for `url()`. 
